### PR TITLE
fix(repositories-rc.json)  current url pointing to 404

### DIFF
--- a/rc/repositories-rc.json
+++ b/rc/repositories-rc.json
@@ -1,6 +1,6 @@
 [
     {
       "id": "AgentK8sRcRepo",
-      "url": "https://raw.githubusercontent.com/armory-io/agent-k8s-spinplug-releases/master/plugins-rc.json"
+      "url": "https://raw.githubusercontent.com/armory-io/agent-k8s-spinplug-releases/master/plugins.json"
     }
 ]


### PR DESCRIPTION
When using this URL: https://raw.githubusercontent.com/armory-io/agent-k8s-spinplug-releases/master/rc/repositories-rc.json

We are downloading this: https://raw.githubusercontent.com/armory-io/agent-k8s-spinplug-releases/master/plugins-rc.json

And it isn't exist (404)